### PR TITLE
coercing json boolean types

### DIFF
--- a/lib/Etcd/Node.pm
+++ b/lib/Etcd/Node.pm
@@ -23,7 +23,7 @@ has created_index  => ( is => 'ro', isa => Int, init_arg => 'createdIndex'  );
 has modified_index => ( is => 'ro', isa => Int, init_arg => 'modifiedIndex' );
 has ttl            => ( is => 'ro', isa => Int );
 has expiration     => ( is => 'ro', isa => $ISO8601 );
-has dir            => ( is => 'ro', isa => Bool );
+has dir            => ( is => 'ro', isa => Bool, coerce => sub { !! $_[0] } );
 
 has nodes => (
     is => 'ro',

--- a/t/13-type-coercion.t
+++ b/t/13-type-coercion.t
@@ -1,0 +1,25 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Etcd::Node;
+
+subtest node_dir_boolean_serialization => sub {
+    is(Etcd::Node->new(key => 'foo', dir => 1)->dir(), 1);
+    is(Etcd::Node->new(key => 'foo', dir => 0)->dir(), '');
+    is(Etcd::Node->new(key => 'foo')->dir(), undef);
+
+    is(Etcd::Node->new(key => 'foo', dir => true->new())->dir(), 1);
+    is(Etcd::Node->new(key => 'foo', dir => false->new())->dir(), '');
+};
+
+package true;
+use overload '0+' => sub { 1 };
+sub new { bless { }, shift }
+
+package false;
+use overload '0+' => sub { 0 };
+sub new { bless { }, shift }


### PR DESCRIPTION
When JSON::SX is available, it is used instead of JSON and that modified the behavior of boolean types.  Moo was not able to correctly convert JSON::XS::Boolean types to Bool and was spitting out warnings.  This branch coerces those types.
